### PR TITLE
AKS-Cluster hinzugefügt | Key-Vault ergänzt 

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,11 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version = "1.4.0"
+  hashes = [
+    "h1:/zBp78avkj22m4qGF1DpKunBQJwHJCVbQTfBsvCrA40=",
+    "zh:07aa14f0925bf0486f8cb8ee33fecc466ea3446d95aef33db598b01d2198dcb9",
+    "zh:0ce1b196d11a507ced54a0641db4112a0e0b6bd85d756a768b146dff630a9661",
+    "zh:166a705b58d25f133ccc35ae601b41a1322c8a78f3a58f2ef5082b16dc56f46e",
+    "zh:1c098e4eb420a98ac541d1a68a534f848f2b19125605fd6ed3bbdbf877d748c6",
+    "zh:326cffab3b598f70b55a470b6cc3ccea417c71523066c1712bf5ac07f21aded7",
+    "zh:4cf651bb26faf96db37ef91d44c251ecc0034a964d695d16a91f24d752805f96",
+    "zh:4f508b7ab711026f7a876625695938c82265d8d5a11bf421e7c8e6c9a541cdd5",
+    "zh:5cdde77636310bf5fc2cb9fdcde0102e7c3689f0c75326a66f128eaf5d02d2f3",
+    "zh:748261e8370370db5ab1f3d9b8d5b050799e07a94f1dafe4bc6721cae04ca15d",
+    "zh:c8f90ec99708e7c8bb9fb8c09b1a816c7370435271895ff142d7f2f8d8d81951",
+    "zh:eb53d13fe64b14b322ac17eee842bd9ef338c178f902700a9033238b2aa95044",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.56.0"
   constraints = "2.56.0"
   hashes = [
-    "h1:aX24zY2dhP8rq4NEvUjjI2AxV6C7f9OkYGrtFXaoXs4=",
     "h1:nTw9fg12T1tsASm+jqBUVABfxe7Tje+5ho7vbBavU4Y=",
     "zh:1994185185046df38eb1d1ad3c3b07e4f964224e4ab756957473b754f6aec75c",
     "zh:202556c142f001830dd4514d475dc747f863ad588382c43daa604d53761f59f5",
@@ -24,7 +41,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [
-    "h1:EPIax4Ftp2SNdB9pUfoSjxoueDoLc/Ck3EUoeX0Dvsg=",
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
     "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,11 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version = "1.4.0"
+  hashes = [
+    "h1:/zBp78avkj22m4qGF1DpKunBQJwHJCVbQTfBsvCrA40=",
+    "zh:07aa14f0925bf0486f8cb8ee33fecc466ea3446d95aef33db598b01d2198dcb9",
+    "zh:0ce1b196d11a507ced54a0641db4112a0e0b6bd85d756a768b146dff630a9661",
+    "zh:166a705b58d25f133ccc35ae601b41a1322c8a78f3a58f2ef5082b16dc56f46e",
+    "zh:1c098e4eb420a98ac541d1a68a534f848f2b19125605fd6ed3bbdbf877d748c6",
+    "zh:326cffab3b598f70b55a470b6cc3ccea417c71523066c1712bf5ac07f21aded7",
+    "zh:4cf651bb26faf96db37ef91d44c251ecc0034a964d695d16a91f24d752805f96",
+    "zh:4f508b7ab711026f7a876625695938c82265d8d5a11bf421e7c8e6c9a541cdd5",
+    "zh:5cdde77636310bf5fc2cb9fdcde0102e7c3689f0c75326a66f128eaf5d02d2f3",
+    "zh:748261e8370370db5ab1f3d9b8d5b050799e07a94f1dafe4bc6721cae04ca15d",
+    "zh:c8f90ec99708e7c8bb9fb8c09b1a816c7370435271895ff142d7f2f8d8d81951",
+    "zh:eb53d13fe64b14b322ac17eee842bd9ef338c178f902700a9033238b2aa95044",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.56.0"
   constraints = "2.56.0"
   hashes = [
-    "h1:aX24zY2dhP8rq4NEvUjjI2AxV6C7f9OkYGrtFXaoXs4=",
     "h1:nTw9fg12T1tsASm+jqBUVABfxe7Tje+5ho7vbBavU4Y=",
     "zh:1994185185046df38eb1d1ad3c3b07e4f964224e4ab756957473b754f6aec75c",
     "zh:202556c142f001830dd4514d475dc747f863ad588382c43daa604d53761f59f5",
@@ -25,7 +42,6 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.0"
   constraints = "3.1.0"
   hashes = [
-    "h1:EPIax4Ftp2SNdB9pUfoSjxoueDoLc/Ck3EUoeX0Dvsg=",
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",

--- a/infrastructure/functions/main.tf
+++ b/infrastructure/functions/main.tf
@@ -1,14 +1,10 @@
-resource "azurerm_resource_group" "fap-backend-resource-group" {
-  name     = "fap-backend-application"
-  location = var.azure_location
-}
-
 resource "azurerm_storage_account" "fap-backend-storage-account" {
   name                     = "fapbackendstorageaccount"
-  resource_group_name      = azurerm_resource_group.fap-backend-resource-group.name
-  location                 = azurerm_resource_group.fap-backend-resource-group.location
+  resource_group_name      = var.prod_resource_group.name
+  location                 = var.prod_resource_group.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  tags = var.azure_tags
 }
 
 resource "azurerm_storage_container" "fap-backend-storage-container" {
@@ -59,9 +55,10 @@ data "azurerm_storage_account_sas" "fap-backend-storage-account-sas" {
 
 resource "azurerm_app_service_plan" "fap-backend-service-plan" {
   name                = "fap-backend-service-plan"
-  location            = azurerm_resource_group.fap-backend-resource-group.location
-  resource_group_name = azurerm_resource_group.fap-backend-resource-group.name
+  location            = var.prod_resource_group.location
+  resource_group_name = var.prod_resource_group.fap-backend-resource-group.name
   kind                = "functionapp"
+  tags = var.azure_tags
   sku {
     tier = "Dynamic"
     size = "Y1"
@@ -70,8 +67,8 @@ resource "azurerm_app_service_plan" "fap-backend-service-plan" {
 
 resource "azurerm_function_app" "fap-backend-function-app" {
   name                       = "fap-backend-function-app"
-  location                   = azurerm_resource_group.fap-backend-resource-group.location
-  resource_group_name        = azurerm_resource_group.fap-backend-resource-group.name
+  location                   = var.prod_resource_group.fap-backend-resource-group.location
+  resource_group_name        = var.prod_resource_group.fap-backend-resource-group.name
   app_service_plan_id        = azurerm_app_service_plan.fap-backend-service-plan.id
   storage_account_name       = azurerm_storage_account.fap-backend-storage-account.name
   storage_account_access_key = azurerm_storage_account.fap-backend-storage-account.primary_access_key

--- a/infrastructure/functions/main.tf
+++ b/infrastructure/functions/main.tf
@@ -67,8 +67,8 @@ resource "azurerm_app_service_plan" "fap-backend-service-plan" {
 
 resource "azurerm_function_app" "fap-backend-function-app" {
   name                       = "fap-backend-function-app"
-  location                   = var.prod_resource_group.fap-backend-resource-group.location
-  resource_group_name        = var.prod_resource_group.fap-backend-resource-group.name
+  location                   = var.prod_resource_group.location
+  resource_group_name        = var.prod_resource_group.name
   app_service_plan_id        = azurerm_app_service_plan.fap-backend-service-plan.id
   storage_account_name       = azurerm_storage_account.fap-backend-storage-account.name
   storage_account_access_key = azurerm_storage_account.fap-backend-storage-account.primary_access_key

--- a/infrastructure/functions/main.tf
+++ b/infrastructure/functions/main.tf
@@ -3,14 +3,6 @@ resource "azurerm_resource_group" "fap-backend-resource-group" {
   location = var.azure_location
 }
 
-resource "random_id" "storage_name" {
-  byte_length = 2
-}
-
-resource "random_id" "app_service_plan_name" {
-  byte_length = 2
-}
-
 resource "azurerm_storage_account" "fap-backend-storage-account" {
   name                     = "fapbackendstorageaccount"
   resource_group_name      = azurerm_resource_group.fap-backend-resource-group.name

--- a/infrastructure/functions/main.tf
+++ b/infrastructure/functions/main.tf
@@ -2,7 +2,6 @@ resource "azurerm_resource_group" "fap-function-store" {
   name     = "fap-backend-application"
   location = var.azure_location
 }
-
 resource "random_id" "storage_name" {
   byte_length = 2
 }

--- a/infrastructure/functions/main.tf
+++ b/infrastructure/functions/main.tf
@@ -56,7 +56,7 @@ data "azurerm_storage_account_sas" "fap-backend-storage-account-sas" {
 resource "azurerm_app_service_plan" "fap-backend-service-plan" {
   name                = "fap-backend-service-plan"
   location            = var.prod_resource_group.location
-  resource_group_name = var.prod_resource_group.fap-backend-resource-group.name
+  resource_group_name = var.prod_resource_group.name
   kind                = "functionapp"
   tags = var.azure_tags
   sku {

--- a/infrastructure/functions/output.tf
+++ b/infrastructure/functions/output.tf
@@ -1,3 +1,0 @@
-output "prod_resource_group" {
-  value = azurerm_resource_group.fap-backend-resource-group
-}

--- a/infrastructure/functions/output.tf
+++ b/infrastructure/functions/output.tf
@@ -1,3 +1,3 @@
-output "prod-resource-group" {
-  value = azurerm_resource_group.fap-function-store
+output "prod_resource_group" {
+  value = azurerm_resource_group.fap-backend-resource-group
 }

--- a/infrastructure/functions/output.tf
+++ b/infrastructure/functions/output.tf
@@ -1,0 +1,3 @@
+output "prod-resource-group-name" {
+  value = azurerm_resource_group.fap-function-store.name
+}

--- a/infrastructure/functions/output.tf
+++ b/infrastructure/functions/output.tf
@@ -1,3 +1,3 @@
-output "prod-resource-group-name" {
-  value = azurerm_resource_group.fap-function-store.name
+output "prod-resource-group" {
+  value = azurerm_resource_group.fap-function-store
 }

--- a/infrastructure/functions/variables.tf
+++ b/infrastructure/functions/variables.tf
@@ -1,7 +1,7 @@
 variable "azure_tags" {}
 variable "azure_location" {}
 variable "google_api_key" {}
-
+variable "prod_resource_group" {}
 variable "azure_resource_group_name" {
   description = "Azure resource group name"
   default     = "friends-and-places"

--- a/infrastructure/kubernetes/main.tf
+++ b/infrastructure/kubernetes/main.tf
@@ -1,30 +1,24 @@
-resource "azurerm_kubernetes_cluster" "example" {
-  name                = "example-aks1"
+resource "azurerm_kubernetes_cluster" "fap-frontend-application-kubernetes-cluster" {
+  name                = "fap-frontend-application"
   location            = var.azure_location
-  resource_group_name = var.prod-resource-group-name
+  resource_group_name = var.prod-resource-group.name
   dns_prefix          = "fap-server"
+  node_resource_group = "fap-frontend-application"
 
   default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_D2_v2"
+    name                = "default"
+    max_count           = 1
+    min_count           = 3
+    max_pods            = 2
+    vm_size             = "Standard_B1S"
+    type                = "VirtualMachineScaleSets"
+    enable_auto_scaling = true
   }
-
   identity {
     type = "SystemAssigned"
   }
 
   tags = {
-    Environment = "Production"
+    tfmanaged = "true"
   }
-}
-
-output "client_certificate" {
-  value = azurerm_kubernetes_cluster.example.kube_config.0.client_certificate
-  sensitive = true
-}
-
-output "kube_config" {
-  value = azurerm_kubernetes_cluster.example.kube_config_raw
-  sensitive = true
 }

--- a/infrastructure/kubernetes/main.tf
+++ b/infrastructure/kubernetes/main.tf
@@ -1,7 +1,7 @@
 resource "azurerm_kubernetes_cluster" "fap-frontend-application-kubernetes-cluster" {
   name                = "fap-frontend-application"
   location            = var.azure_location
-  resource_group_name = var.prod-resource-group.name
+  resource_group_name = var.prod_resource_group.name
   dns_prefix          = "fap-server"
   node_resource_group = "fap-frontend-application"
 
@@ -18,7 +18,5 @@ resource "azurerm_kubernetes_cluster" "fap-frontend-application-kubernetes-clust
     type = "SystemAssigned"
   }
 
-  tags = {
-    tfmanaged = "true"
-  }
+  tags = var.azure_tags
 }

--- a/infrastructure/kubernetes/main.tf
+++ b/infrastructure/kubernetes/main.tf
@@ -1,0 +1,30 @@
+resource "azurerm_kubernetes_cluster" "example" {
+  name                = "example-aks1"
+  location            = var.azure_location
+  resource_group_name = var.prod-resource-group-name
+  dns_prefix          = "fap-server"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    Environment = "Production"
+  }
+}
+
+output "client_certificate" {
+  value = azurerm_kubernetes_cluster.example.kube_config.0.client_certificate
+  sensitive = true
+}
+
+output "kube_config" {
+  value = azurerm_kubernetes_cluster.example.kube_config_raw
+  sensitive = true
+}

--- a/infrastructure/kubernetes/output.tf
+++ b/infrastructure/kubernetes/output.tf
@@ -1,0 +1,6 @@
+output "fap-kubernetes-secrets" {
+  value = {
+    kubernetes-client-certificate = azurerm_kubernetes_cluster.fap-frontend-application-kubernetes-cluster.kube_config.0.client_certificate,
+    kubernetes-config-raw = azurerm_kubernetes_cluster.fap-frontend-application-kubernetes-cluster.kube_config_raw
+  }
+}

--- a/infrastructure/kubernetes/output.tf
+++ b/infrastructure/kubernetes/output.tf
@@ -1,4 +1,4 @@
-output "fap-kubernetes-secrets" {
+output "fap_kubernetes_secrets" {
   value = {
     kubernetes-client-certificate = azurerm_kubernetes_cluster.fap-frontend-application-kubernetes-cluster.kube_config.0.client_certificate,
     kubernetes-config-raw = azurerm_kubernetes_cluster.fap-frontend-application-kubernetes-cluster.kube_config_raw

--- a/infrastructure/kubernetes/variables.tf
+++ b/infrastructure/kubernetes/variables.tf
@@ -1,2 +1,2 @@
-variable "prod-resource-group-name" {}
+variable "prod-resource-group" {}
 variable "azure_location" {}

--- a/infrastructure/kubernetes/variables.tf
+++ b/infrastructure/kubernetes/variables.tf
@@ -1,0 +1,2 @@
+variable "prod-resource-group-name" {}
+variable "azure_location" {}

--- a/infrastructure/kubernetes/variables.tf
+++ b/infrastructure/kubernetes/variables.tf
@@ -1,2 +1,3 @@
-variable "prod-resource-group" {}
+variable "prod_resource_group" {}
 variable "azure_location" {}
+variable "azure_tags" {}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -15,7 +15,7 @@ module "kubernetes" {
 
 module "secrets" {
   source = "./secrets"
-  prod_resource_group    = azurerm_resource_group.fap-backend-resource-group
+  prod_resource_group    = azurerm_resource_group.fap-prod-resource-group
   fap_kubernetes_secrets = module.kubernetes.fap_kubernetes_secrets
   azure_tags     = var.azure_tags
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,7 +8,7 @@ module "functions" {
 
 module "kubernetes" {
   source = "./kubernetes"
-  prod_resource_group = azurerm_resource_group.fap-backend-resource-group
+  prod_resource_group = azurerm_resource_group.fap-prod-resource-group
   azure_location      = var.azure_location
   azure_tags     = var.azure_tags
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -2,3 +2,9 @@ module "functions" {
   source = "./functions"
   azure_location = var.azure_location
 }
+
+module "kubernetes" {
+  source = "./kubernetes"
+  prod-resource-group-name = module.functions.prod-resource-group-name
+  azure_location = var.azure_location
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -6,6 +6,12 @@ module "functions" {
 
 module "kubernetes" {
   source = "./kubernetes"
-  prod-resource-group-name = module.functions.prod-resource-group-name
-  azure_location = var.azure_location
+  prod-resource-group = module.functions.prod-resource-group
+  azure_location      = var.azure_location
+}
+
+module "secrets" {
+  source = "./secrets"
+  prod-resource-group    = module.functions.prod-resource-group
+  fap-kubernetes-secrets = module.kubernetes.fap-kubernetes-secrets
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -20,8 +20,8 @@ module "secrets" {
   azure_tags     = var.azure_tags
 }
 
-resource "azurerm_resource_group" "fap-backend-resource-group" {
-  name     = "fap-backend-application"
+resource "azurerm_resource_group" "fap-prod-resource-group" {
+  name     = "fap-prod-application"
   location = var.azure_location
   tags = var.azure_tags
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,6 +1,6 @@
 module "functions" {
   source         = "./functions"
-  prod_resource_group = azurerm_resource_group.fap-backend-resource-group
+  prod_resource_group = azurerm_resource_group.fap-prod-resource-group
   azure_tags     = var.azure_tags
   azure_location = var.azure_location
   google_api_key = var.google_api_key

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,5 +1,6 @@
 module "functions" {
   source         = "./functions"
+  prod_resource_group = azurerm_resource_group.fap-backend-resource-group
   azure_tags     = var.azure_tags
   azure_location = var.azure_location
   google_api_key = var.google_api_key
@@ -7,14 +8,20 @@ module "functions" {
 
 module "kubernetes" {
   source = "./kubernetes"
-  prod_resource_group = module.functions.prod_resource_group
+  prod_resource_group = azurerm_resource_group.fap-backend-resource-group
   azure_location      = var.azure_location
   azure_tags     = var.azure_tags
 }
 
 module "secrets" {
   source = "./secrets"
-  prod_resource_group    = module.functions.prod_resource_group
+  prod_resource_group    = azurerm_resource_group.fap-backend-resource-group
   fap_kubernetes_secrets = module.kubernetes.fap_kubernetes_secrets
   azure_tags     = var.azure_tags
+}
+
+resource "azurerm_resource_group" "fap-backend-resource-group" {
+  name     = "fap-backend-application"
+  location = var.azure_location
+  tags = var.azure_tags
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -7,12 +7,14 @@ module "functions" {
 
 module "kubernetes" {
   source = "./kubernetes"
-  prod-resource-group = module.functions.prod-resource-group
+  prod_resource_group = module.functions.prod_resource_group
   azure_location      = var.azure_location
+  azure_tags     = var.azure_tags
 }
 
 module "secrets" {
   source = "./secrets"
-  prod-resource-group    = module.functions.prod-resource-group
-  fap-kubernetes-secrets = module.kubernetes.fap-kubernetes-secrets
+  prod_resource_group    = module.functions.prod_resource_group
+  fap_kubernetes_secrets = module.kubernetes.fap_kubernetes_secrets
+  azure_tags     = var.azure_tags
 }

--- a/infrastructure/secrets/main.tf
+++ b/infrastructure/secrets/main.tf
@@ -1,0 +1,48 @@
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "fap-key-vault" {
+  name                       = "fap-key-vault"
+  location                   = var.prod-resource-group.location
+  resource_group_name        = var.prod-resource-group.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  enabled_for_deployment     = true
+  tags = {
+    tfmanaged = "true"
+  }
+}
+
+data "azuread_users" "users" {
+  user_principal_names = var.azure-user
+}
+
+resource "azurerm_key_vault_access_policy" "fap-user-access-policy" {
+  key_vault_id = azurerm_key_vault.fap-key-vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  for_each     = toset(data.azuread_users.users.object_ids)
+  object_id    = each.value
+
+  key_permissions = [
+    "create",
+    "get",
+  ]
+
+  secret_permissions = [
+    "set",
+    "get",
+    "delete",
+    "purge",
+    "recover"
+  ]
+}
+
+resource "azurerm_key_vault_secret" "kubernetes-secret" {
+  for_each     = var.fap-kubernetes-secrets
+  name         = each.key
+  value        = each.value
+  key_vault_id = azurerm_key_vault.fap-key-vault.id
+  tags = {
+    tfmanaged = "true"
+  }
+}

--- a/infrastructure/secrets/main.tf
+++ b/infrastructure/secrets/main.tf
@@ -2,19 +2,17 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "fap-key-vault" {
   name                       = "fap-key-vault"
-  location                   = var.prod-resource-group.location
-  resource_group_name        = var.prod-resource-group.name
+  location                   = var.prod_resource_group.location
+  resource_group_name        = var.prod_resource_group.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
   enabled_for_deployment     = true
-  tags = {
-    tfmanaged = "true"
-  }
+  tags                       = var.azure_tags
 }
 
 data "azuread_users" "users" {
-  user_principal_names = var.azure-user
+  user_principal_names = var.azure_user
 }
 
 resource "azurerm_key_vault_access_policy" "fap-user-access-policy" {
@@ -38,11 +36,9 @@ resource "azurerm_key_vault_access_policy" "fap-user-access-policy" {
 }
 
 resource "azurerm_key_vault_secret" "kubernetes-secret" {
-  for_each     = var.fap-kubernetes-secrets
+  for_each     = var.fap_kubernetes_secrets
   name         = each.key
   value        = each.value
   key_vault_id = azurerm_key_vault.fap-key-vault.id
-  tags = {
-    tfmanaged = "true"
-  }
+  tags = var.azure_tags
 }

--- a/infrastructure/secrets/main.tf
+++ b/infrastructure/secrets/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_key_vault" "fap-key-vault" {
 }
 
 data "azuread_users" "users" {
-  user_principal_names = var.azure_user
+  user_principal_names = var.azure_users
 }
 
 resource "azurerm_key_vault_access_policy" "fap-user-access-policy" {

--- a/infrastructure/secrets/variables.tf
+++ b/infrastructure/secrets/variables.tf
@@ -1,6 +1,7 @@
-variable "prod-resource-group" {}
-variable "fap-kubernetes-secrets" {}
-variable "azure-user" {
+variable "prod_resource_group" {}
+variable "fap_kubernetes_secrets" {}
+variable "azure_tags" {}
+variable "azure_user" {
   default = [
     "Leon.schoenhoffGW_outlook.com#EXT#@friendsandplaces.onmicrosoft.com",
     "maltemorgenstern_gmail.com#EXT#@friendsandplaces.onmicrosoft.com",

--- a/infrastructure/secrets/variables.tf
+++ b/infrastructure/secrets/variables.tf
@@ -1,0 +1,10 @@
+variable "prod-resource-group" {}
+variable "fap-kubernetes-secrets" {}
+variable "azure-user" {
+  default = [
+    "Leon.schoenhoffGW_outlook.com#EXT#@friendsandplaces.onmicrosoft.com",
+    "maltemorgenstern_gmail.com#EXT#@friendsandplaces.onmicrosoft.com",
+    "bjoern.schaefer2_web.de#EXT#@friendsandplaces.onmicrosoft.com",
+    "Nick.A.Stelzer_studmail.w-hs.de#EXT#@friendsandplaces.onmicrosoft.com"
+  ]
+}

--- a/infrastructure/secrets/variables.tf
+++ b/infrastructure/secrets/variables.tf
@@ -1,7 +1,7 @@
 variable "prod_resource_group" {}
 variable "fap_kubernetes_secrets" {}
 variable "azure_tags" {}
-variable "azure_user" {
+variable "azure_users" {
   default = [
     "Leon.schoenhoffGW_outlook.com#EXT#@friendsandplaces.onmicrosoft.com",
     "maltemorgenstern_gmail.com#EXT#@friendsandplaces.onmicrosoft.com",


### PR DESCRIPTION
Kubernetes Cluster hinzugefügt. Die Einstellungen sind aktuell noch sehr Basic.
Das Cluster kann bei bedarf zwischen 1er und 3 VM's mit je 2 Pods skallieren.

Die Secrets des Clusters werden in einem Azure Key Vault hinterlegt. 

Closes #7.