### PR TITLE
Add certificate permission and fix spelling

### DIFF
--- a/infrastructure/secrets/main.tf
+++ b/infrastructure/secrets/main.tf
@@ -29,10 +29,31 @@ resource "azurerm_key_vault_access_policy" "fap-user-access-policy" {
   secret_permissions = [
     "set",
     "get",
-    "delete",
+    "Delete",
     "purge",
-    "recover"
+    "recover",
+    "list",
+    "Backup",
+    "restore"
   ]
+
+  certificate_permissions = [
+  "Backup",
+  "Create",
+  "Delete",
+  "DeleteIssuers",
+  "Get",
+  "GetIssuers",
+  "Import",
+  "List",
+  "ListIssuers",
+  "ManageContacts",
+  "ManageIssuers",
+  "Purge",
+  "Recover",
+  "Restore",
+  "SetIssuers",
+  "Update"]
 }
 
 resource "azurerm_key_vault_secret" "kubernetes-client-certificate" {


### PR DESCRIPTION
# KeyVault Berechtigungen und weiteres Vorgehen.

> Durch diesen PR werden Änderungen an den Berechtigungen des Azure KeyVault vorgenommen.

Es kann sein, dass die Berechtigungen des API-Users nicht ausreichen um die Berechtigungen zu ändern.

In diesem Fall muss die Ressource mit `terraform taint module.infrastructure.module.secrets.azurerm_key_vault.fap-key-vault` markiert werden. Dadurch wird sie beim nächsten `terraform apply` erneuert.

*WICHTIG:* Vorher muss der Azure-Name der Ressource geändert werden, da es eine 14-Tätige Retention-Policy für KeyVaults gibt.

Closes #36 